### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # withdrawer
 
-Golang utility for proving and finalizing ETH withdrawals from op-stack chains.
+Go utility for proving and finalizing ETH withdrawals from op-stack chains.
 
 <!-- Badge row 1 - status -->
 


### PR DESCRIPTION
Golang utility for proving and finalizing ETH withdrawals from op-stack chains." - It might be more clear to specify "Go" instead of "Golang" since "Go" is the official name of the language.